### PR TITLE
Equivalent mechanics

### DIFF
--- a/azusa/curve_probabilities.py
+++ b/azusa/curve_probabilities.py
@@ -185,6 +185,11 @@ def calculate_cmc_probs(num_cards_in_library,
                         max_mana=5,
                         num_threads=None,
                         progress_bar=tqdm.tqdm):
+    for producer_id in mana_producers.keys():
+        producer = PRODUCERS[producer_id]
+        if producer.warning:
+            logging.warning(f'{producer_id}: {producer.warning}')
+
     num_opening_hands = 0
     for num_lands_in_hand in range(min(num_lands, 7) + 1):
         for num_producers_in_hand in range(

--- a/azusa/mana_producers.py
+++ b/azusa/mana_producers.py
@@ -13,6 +13,14 @@ class NonlandCard:
     def fast(self):
         pass
 
+    def equivalency_test(self, other, fields):
+        if self.__class__ != other.__class__:
+            return False
+        for field in fields:
+            if getattr(self, field) != getattr(other, field):
+                return False
+        return True
+
 
 @dataclass
 class ManaPermanent(NonlandCard):
@@ -22,6 +30,10 @@ class ManaPermanent(NonlandCard):
     payoff: int
     enters_tapped: bool
     warning: str = None
+
+    def equivalent(self, other):
+        return self.equivalency_test(
+            other, ['cmc', 'input_cost', 'payoff', 'enters_tapped'])
 
     def ramp(self, state):
         return self.payoff
@@ -48,6 +60,12 @@ class LandFetcher(NonlandCard):
     num_lands_to_hand: int = 0
     num_lands_to_sac: int = 0
     warning: str = None
+
+    def equivalent(self, other):
+        return self.equivalency_test(other, [
+            'cmc', 'num_lands_to_play', 'num_tapped_lands_to_play',
+            'num_lands_to_hand', 'num_lands_to_sac'
+        ])
 
     def ramp(self, state):
         return self.num_lands_to_play + self.num_tapped_lands_to_play - self.num_lands_to_sac
@@ -85,6 +103,9 @@ class ExtraLands(NonlandCard):
     num_extra_lands: int
     warning: str = None
 
+    def equivalent(self, other):
+        return self.equivalency_test(other, ['cmc', 'num_extra_lands'])
+
     def ramp(self, state):
         return min(self.num_extra_lands, state.num_lands_in_hand)
 
@@ -114,6 +135,12 @@ class SacPermanent(NonlandCard):
     num_tapped_lands_to_play: int = 0
     num_lands_to_hand: int = 0
     warning: str = None
+
+    def equivalent(self, other):
+        return self.equivalency_test(other, [
+            'cmc', 'activation_cost', 'num_lands_to_play',
+            'num_tapped_lands_to_play', 'num_lands_to_hand'
+        ])
 
     def ramp(self, state):
         return self.num_lands_to_play + self.num_tapped_lands_to_play

--- a/azusa/mana_producers.py
+++ b/azusa/mana_producers.py
@@ -21,6 +21,7 @@ class ManaPermanent(NonlandCard):
     input_cost: int
     payoff: int
     enters_tapped: bool
+    warning: str = None
 
     def ramp(self, state):
         return self.payoff
@@ -46,6 +47,7 @@ class LandFetcher(NonlandCard):
     num_tapped_lands_to_play: int = 0
     num_lands_to_hand: int = 0
     num_lands_to_sac: int = 0
+    warning: str = None
 
     def ramp(self, state):
         return self.num_lands_to_play + self.num_tapped_lands_to_play - self.num_lands_to_sac
@@ -81,6 +83,7 @@ class ExtraLands(NonlandCard):
     name: str
     cmc: int
     num_extra_lands: int
+    warning: str = None
 
     def ramp(self, state):
         return min(self.num_extra_lands, state.num_lands_in_hand)
@@ -110,6 +113,7 @@ class SacPermanent(NonlandCard):
     num_lands_to_play: int = 0
     num_tapped_lands_to_play: int = 0
     num_lands_to_hand: int = 0
+    warning: str = None
 
     def ramp(self, state):
         return self.num_lands_to_play + self.num_tapped_lands_to_play
@@ -169,7 +173,7 @@ PRODUCERS = {
 
     'Coldsteel Heart':  ManaPermanent(name='Coldsteel Heart',  cmc=2, input_cost=0, payoff=1, enters_tapped=True),
 
-    # 2 For 1s
+    # 2 MANA ROCKS
     'Fellwar Stone':        ManaPermanent(name='Fellwar Stone',        cmc=2, input_cost=0, payoff=1, enters_tapped=False),
     'Fractured Powerstone': ManaPermanent(name='Fractured Powerstone', cmc=2, input_cost=0, payoff=1, enters_tapped=False),
     'Mind Stone':           ManaPermanent(name='Mind Stone',           cmc=2, input_cost=0, payoff=1, enters_tapped=False),
@@ -437,16 +441,16 @@ PRODUCERS = {
     'Elvish Aberration': ManaPermanent(name='Elvish Aberration', cmc=6, input_cost=0, payoff=3, enters_tapped=True),
 
     # ENCHANTMENTS
-    'Fertile Ground':   ManaPermanent(name='Fertile Ground',   cmc=2, input_cost=0, payoff=1, enters_tapped=True),
-    'Gift of Paradise': ManaPermanent(name='Gift of Paradise', cmc=3, input_cost=0, payoff=1, enters_tapped=True),
-    'Glittering Frost': ManaPermanent(name='Glittering Frost', cmc=3, input_cost=0, payoff=1, enters_tapped=True),
-    'Market Festival':  ManaPermanent(name='Market Festival',  cmc=4, input_cost=0, payoff=1, enters_tapped=True),
-    'Overgrowth':       ManaPermanent(name='Overgrowth',       cmc=3, input_cost=0, payoff=2, enters_tapped=True),
-    'Sheltered Aerie':  ManaPermanent(name='Sheltered Aerie',  cmc=3, input_cost=0, payoff=1, enters_tapped=True),
-    'Utopia Sprawl':    ManaPermanent(name='Utopia Sprawl',    cmc=1, input_cost=0, payoff=1, enters_tapped=True),
-    'Weirding Wood':    ManaPermanent(name='Weirding Wood',    cmc=3, input_cost=0, payoff=1, enters_tapped=True),
-    'Wild Growth':      ManaPermanent(name='Wild Growth',      cmc=1, input_cost=0, payoff=1, enters_tapped=True),
-    'Wolfwillow Haven': ManaPermanent(name='Wolfwillow Haven', cmc=2, input_cost=0, payoff=1, enters_tapped=True),
+    'Fertile Ground':   ManaPermanent(name='Fertile Ground',   cmc=2, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Gift of Paradise': ManaPermanent(name='Gift of Paradise', cmc=3, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Glittering Frost': ManaPermanent(name='Glittering Frost', cmc=3, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Market Festival':  ManaPermanent(name='Market Festival',  cmc=4, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Overgrowth':       ManaPermanent(name='Overgrowth',       cmc=3, input_cost=0, payoff=2, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Sheltered Aerie':  ManaPermanent(name='Sheltered Aerie',  cmc=3, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Utopia Sprawl':    ManaPermanent(name='Utopia Sprawl',    cmc=1, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Weirding Wood':    ManaPermanent(name='Weirding Wood',    cmc=3, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Wild Growth':      ManaPermanent(name='Wild Growth',      cmc=1, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
+    'Wolfwillow Haven': ManaPermanent(name='Wolfwillow Haven', cmc=2, input_cost=0, payoff=1, enters_tapped=True, warning='Enchant lands take 1 turn to activate'),
 
     # PLANESWALKERS
     'Domri, Anarch of Bolas': ManaPermanent(name='Domri, Anarch of Bolas', cmc=3, input_cost=0, payoff=1, enters_tapped=False),
@@ -471,7 +475,7 @@ PRODUCERS = {
     'Harrow':              LandFetcher(name='Harrow',              cmc=3, num_lands_to_play=2, num_lands_to_sac=1),
     'Primal Growth':       LandFetcher(name='Primal Growth',       cmc=3, num_lands_to_play=1),
     'Recross the Paths':   LandFetcher(name='Recross the Paths',   cmc=3, num_lands_to_play=1),
-    'Search for Tomorrow': LandFetcher(name='Search for Tomorrow', cmc=3, num_lands_to_play=1),
+    'Search for Tomorrow': LandFetcher(name='Search for Tomorrow', cmc=3, num_lands_to_play=1, warning='Suspend not yet implemented'),
     'Spoils of Victory':   LandFetcher(name='Spoils of Victory',   cmc=3, num_lands_to_play=1),
     'Wood Elves':          LandFetcher(name='Wood Elves',          cmc=3, num_lands_to_play=1),
 
@@ -486,11 +490,15 @@ PRODUCERS = {
     'Hour of Promise':  LandFetcher(name='Hour of Promise',  cmc=5, num_tapped_lands_to_play=2),
 
     # EXTRA LANDS
-    'Azusa, Lost but Seeking':    ExtraLands(name='Azusa, Lost but Seeking',    cmc=3, num_extra_lands=2),
-    'Dryad of the Ilysian Grove': ExtraLands(name='Dryad of the Ilysian Grove', cmc=3, num_extra_lands=1),
-    'Ghirapur Orrery':            ExtraLands(name='Ghirapur Orrery',            cmc=4, num_extra_lands=1),
-    'Exploration':                ExtraLands(name='Exploration',                cmc=1, num_extra_lands=1),
-    'Wayward Swordtooth':         ExtraLands(name='Wayward Swordtooth',         cmc=3, num_extra_lands=1),
+    'Aesi, Tyrant of Gyre Strait': ExtraLands(name='Aesi, Tyrant of Gyre Strait', cmc=6, num_extra_lands=1, warning='Extra draw not yet implemented'),
+    'Azusa, Lost but Seeking':     ExtraLands(name='Azusa, Lost but Seeking',     cmc=3, num_extra_lands=2),
+    'Dryad of the Ilysian Grove':  ExtraLands(name='Dryad of the Ilysian Grove',  cmc=3, num_extra_lands=1),
+    'Ghirapur Orrery':             ExtraLands(name='Ghirapur Orrery',             cmc=4, num_extra_lands=1, warning='Extra draw not yet implemented'),
+    'Exploration':                 ExtraLands(name='Exploration',                 cmc=1, num_extra_lands=1),
+    'Mina and Denn, Wildborn':     ExtraLands(name='Mina and Denn, Wildborn',     cmc=4, num_extra_lands=1),
+    'Oracle of Mul Daya':          ExtraLands(name='Oracle of Mul Daya',          cmc=3, num_extra_lands=1, warning='Top card reveal not yet implemented'),
+    'Rites of Flourishing':        ExtraLands(name='Rites of Flourishing',        cmc=3, num_extra_lands=1, warning='Extra draw not yet implemented'),
+    'Wayward Swordtooth':          ExtraLands(name='Wayward Swordtooth',          cmc=3, num_extra_lands=1),
 
     # SAC ARTIFACTS
     'Burnished Hart':     SacPermanent(name='Burnished Hart',     cmc=3, activation_cost=3, num_tapped_lands_to_play=2),

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='azusa',
-    version='0.1.6',
+    version='0.1.7',
     description='Probability estimator for being on curve in mtg',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The major leap forward in this pull request is that now cards with equivalent mechanics are treated as multiple copies of the same card, vastly reducing the search space.

Other noteable includes are:
- Warnings for not fully functioning cards are printed in both the CLI and GUI.
- Image search for a given deck's mana producers is now cached.